### PR TITLE
Centralize RBAC, gate AI recommendations, and fix media-type, accessibility, and watch progress bugs

### DIFF
--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -5,39 +5,23 @@ import {
   type QueryCtx,
 } from "./_generated/server";
 import { v } from "convex/values";
+import {
+	ADMIN_PERMISSIONS,
+	DEFAULT_ROLE_PERMISSIONS,
+	PERMISSION_ROLES,
+	RBAC_FEATURES,
+	RBAC_ROLE_FEATURES,
+	type PermissionRole,
+	type RbacFeature,
+} from "../shared/rbac";
 
-const DYNAMIC_ROLES = ["video-player", "ai-integrations"] as const;
-const VALID_FEATURES = ["video-player", "ai-recommendations"] as const;
+const VALID_FEATURES = Object.keys(RBAC_FEATURES) as RbacFeature[];
+const DYNAMIC_ROLES = PERMISSION_ROLES;
 
-export type DynamicRbacRole = (typeof DYNAMIC_ROLES)[number];
-export type RbacFeature = (typeof VALID_FEATURES)[number];
-
-const ADMIN_PERMISSIONS: Record<RbacFeature, true> = {
-	"video-player": true,
-	"ai-recommendations": true,
-};
-
-const DEFAULT_PERMISSIONS: Record<
-  DynamicRbacRole,
-  Record<RbacFeature, boolean>
-> = {
-	"video-player": {
-		"video-player": true,
-		"ai-recommendations": false,
-	},
-	"ai-integrations": {
-		"video-player": false,
-		"ai-recommendations": true,
-	},
-};
-
-const ROLE_FEATURES: Record<DynamicRbacRole, RbacFeature> = {
-	"video-player": "video-player",
-	"ai-integrations": "ai-recommendations",
-};
+export type DynamicRbacRole = PermissionRole;
 
 function isValidRoleFeaturePair(role: string, feature: string): boolean {
-	return ROLE_FEATURES[role as DynamicRbacRole] === feature;
+	return RBAC_ROLE_FEATURES[role as DynamicRbacRole] === feature;
 }
 
 async function getUserByToken(
@@ -84,7 +68,7 @@ function isClerkAdmin(identity: Record<string, unknown> | null): boolean {
   return parseClerkPublicMeta(identity)?.isAdmin === true;
 }
 
-async function requireAdmin(ctx: MutationCtx) {
+async function requireAdmin(ctx: QueryCtx | MutationCtx) {
   const identity = await ctx.auth.getUserIdentity();
   if (!identity) throw new Error("Unauthorized");
 
@@ -118,7 +102,7 @@ async function computeRoleFeatures(
       if (existing) {
         if (existing.enabled) enabled = true;
       } else if (
-        DEFAULT_PERMISSIONS[role as DynamicRbacRole]?.[feature] === true
+        DEFAULT_ROLE_PERMISSIONS[role as DynamicRbacRole]?.[feature] === true
       ) {
         enabled = true;
       }
@@ -152,7 +136,7 @@ export async function hasFeature(
       .first();
 
     if (existing?.enabled === true) return true;
-    if (!existing && DEFAULT_PERMISSIONS[role as DynamicRbacRole]?.[feature]) {
+    if (!existing && DEFAULT_ROLE_PERMISSIONS[role as DynamicRbacRole]?.[feature]) {
       return true;
     }
   }
@@ -181,7 +165,7 @@ export async function syncRolePermissions(ctx: MutationCtx) {
 	}
 
 	for (const role of DYNAMIC_ROLES) {
-		const feature = ROLE_FEATURES[role];
+		const feature = RBAC_ROLE_FEATURES[role];
 		const existing = existingPermissions.find(
 			(permission) =>
 				permission.role === role && permission.feature === feature,
@@ -191,7 +175,7 @@ export async function syncRolePermissions(ctx: MutationCtx) {
 			await ctx.db.insert("role_permissions", {
 				role,
 				feature,
-				enabled: DEFAULT_PERMISSIONS[role][feature],
+				enabled: DEFAULT_ROLE_PERMISSIONS[role][feature],
 			});
 		}
 	}
@@ -230,15 +214,17 @@ export const getUserFeatures = query({
 export const getRolePermissions = query({
   args: {},
   handler: async (ctx) => {
+    await requireAdmin(ctx);
+
     const perms = await ctx.db.query("role_permissions").collect();
 
 		const result: Record<string, Record<string, boolean>> = {};
 		for (const role of DYNAMIC_ROLES) {
 			result[role] = {};
-			const feature = ROLE_FEATURES[role];
+			const feature = RBAC_ROLE_FEATURES[role];
 			const perm = perms.find((p) => p.role === role && p.feature === feature);
 			result[role][feature] =
-				perm ? perm.enabled : DEFAULT_PERMISSIONS[role][feature];
+				perm ? perm.enabled : DEFAULT_ROLE_PERMISSIONS[role][feature];
 		}
 
     return result;
@@ -306,6 +292,30 @@ export const setUserRoles = mutation({
       roles: args.roles.length > 0 ? args.roles : undefined,
     });
   },
+});
+
+export const migrateLegacyUserRoles = mutation({
+	args: { batchSize: v.optional(v.number()) },
+	handler: async (ctx, args) => {
+		await requireAdmin(ctx);
+
+		const users = await ctx.db.query("users").collect();
+		let migrated = 0;
+		for (const user of users) {
+			if (migrated >= (args.batchSize ?? 100)) break;
+
+			const legacyRole = user.role;
+			if (!legacyRole || (user.roles?.length ?? 0) > 0) continue;
+
+			await ctx.db.patch(user._id, {
+				roles: Array.from(new Set([...(user.roles ?? []), legacyRole])),
+				role: undefined,
+			});
+			migrated += 1;
+		}
+
+		return { migrated };
+	},
 });
 
 export const listUsers = query({

--- a/convex/recommendations.ts
+++ b/convex/recommendations.ts
@@ -145,6 +145,7 @@ export const saveRecommendations = internalMutation({
     mediaTypePreference: v.optional(v.string()),
     genrePreference: v.optional(v.string()),
     generationType: v.optional(v.string()),
+    listId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await ctx.db.insert("ai_recommendations", {
@@ -156,6 +157,7 @@ export const saveRecommendations = internalMutation({
       mediaTypePreference: args.mediaTypePreference,
       genrePreference: args.genrePreference,
       generationType: args.generationType,
+      listId: args.listId,
       createdAt: Date.now(),
     });
   },
@@ -754,6 +756,7 @@ export const generateRecommendations = action({
       mediaTypePreference: args.mediaTypePreference,
       genrePreference: args.genrePreference,
       generationType: genType,
+      listId: args.listId,
     });
 
     return {
@@ -771,6 +774,8 @@ export const getHomepageRecommendations = query({
     const user = await ctx.auth.getUserIdentity();
     if (!user) return null;
 
+    if (!(await hasFeature(ctx, "ai-recommendations"))) return null;
+
     const dbUser = await getUserByTokenIdentifier(ctx, user.subject);
     if (!dbUser) return null;
 
@@ -784,17 +789,19 @@ export const getHomepageRecommendations = query({
       .withIndex("by_user", (q) => q.eq("userId", dbUser._id))
       .collect();
 
-    const notInterestedIds = new Set(
+    const notInterestedKeys = new Set(
       feedbackList
         .filter((f) => f.feedback === "not_interested")
-        .map((f) => f.tmdbId)
+        .map((f) => `${f.tmdbId}:${f.mediaType}`)
     );
 
     let recs: Recommendation[] = [];
     if (entry && entry.recommendations) {
       try {
         const parsed = JSON.parse(entry.recommendations) as Recommendation[];
-        recs = parsed.filter((r) => r.tmdbId === null || !notInterestedIds.has(r.tmdbId));
+        recs = parsed.filter(
+          (r) => r.tmdbId === null || !notInterestedKeys.has(`${r.tmdbId}:${r.mediaType}`),
+        );
       } catch (e) {
         console.error("Failed to parse homepage recommendations", e);
       }
@@ -827,6 +834,9 @@ export const setRecommendationFeedback = mutation({
   },
   handler: async (ctx, args) => {
     const user = await requireAuthenticatedUser(ctx);
+    if (!(await hasFeature(ctx, "ai-recommendations"))) {
+      throw new Error("Unauthorized: feature not enabled");
+    }
 
     const existing = await ctx.db
       .query("recommendation_feedback")
@@ -858,6 +868,8 @@ export const getRecommendationFeedback = query({
   handler: async (ctx) => {
     const user = await ctx.auth.getUserIdentity();
     if (!user) return [];
+
+    if (!(await hasFeature(ctx, "ai-recommendations"))) return [];
 
     const dbUser = await getUserByTokenIdentifier(ctx, user.subject);
     if (!dbUser) return [];

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -13,6 +13,9 @@ export default defineSchema({
     email: v.optional(v.string()),
 
 	  roles: v.optional(v.array(v.string())),
+
+	  // TODO: Remove this legacy field after migrateLegacyUserRoles has run in production.
+	  role: v.optional(v.string()),
   }).index("by_token", ["tokenIdentifier"]),
 
   watch_items: defineTable({
@@ -105,6 +108,7 @@ export default defineSchema({
     mediaTypePreference: v.optional(v.string()),
     genrePreference: v.optional(v.string()),
 	    generationType: v.optional(v.string()),
+	    listId: v.optional(v.string()),
 	    verified: v.optional(v.boolean()),
     createdAt: v.number(),
   }).index("by_user", ["userId"]),

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -22,11 +22,25 @@ export const store = mutation({
       .first();
 
     if (existing) {
-      await ctx.db.patch(existing._id, {
+      const patch: {
+        name?: string;
+        image?: string;
+        email?: string;
+        roles?: string[];
+        role?: undefined;
+      } = {
         name: args.name,
         image: args.image,
         email: args.email,
-      });
+      };
+
+      // TODO: Remove this legacy-role fallback after migrateLegacyUserRoles has run in production.
+      if ((existing.roles?.length ?? 0) === 0 && existing.role) {
+        patch.roles = Array.from(new Set([existing.role]));
+        patch.role = undefined;
+      }
+
+      await ctx.db.patch(existing._id, patch);
       return existing._id;
     } else {
       const newUserId = await ctx.db.insert("users", {

--- a/convex/watchlist.ts
+++ b/convex/watchlist.ts
@@ -185,7 +185,7 @@ export const updateProgress = mutation({
               ? "watching"
               : undefined);
 
-    const nextProgressStatus = currentProgressStatus ?? inferredProgressStatus;
+    const nextProgressStatus = inferredProgressStatus ?? currentProgressStatus;
 
     if (existing) {
       await ctx.db.patch(existing._id, {
@@ -266,7 +266,7 @@ export const getTrackedTmdbIds = query({
       .withIndex("by_user", (q) => q.eq("userId", user._id))
       .collect();
 
-    return items.map((item) => item.tmdbId);
+    return items.map((item) => ({ tmdbId: item.tmdbId, mediaType: item.mediaType }));
   },
 });
 

--- a/shared/rbac.ts
+++ b/shared/rbac.ts
@@ -1,0 +1,42 @@
+export const RBAC_ROLES = ["admin", "video-player", "ai-integrations"] as const;
+export type RbacRole = (typeof RBAC_ROLES)[number];
+
+export const PERMISSION_ROLES = ["video-player", "ai-integrations"] as const;
+export type PermissionRole = (typeof PERMISSION_ROLES)[number];
+
+export const RBAC_FEATURES = {
+	"video-player": {
+		label: "Video Playback",
+		description: "Built-in video player modal for streaming content",
+	},
+	"ai-recommendations": {
+		label: "AI Recommendations",
+		description:
+			"AI-powered personalized movie and TV recommendations via Gemini",
+	},
+} as const;
+export type RbacFeature = keyof typeof RBAC_FEATURES;
+
+export const RBAC_ROLE_FEATURES: Record<PermissionRole, RbacFeature> = {
+	"video-player": "video-player",
+	"ai-integrations": "ai-recommendations",
+};
+
+export const DEFAULT_ROLE_PERMISSIONS: Record<
+	PermissionRole,
+	Record<RbacFeature, boolean>
+> = {
+	"video-player": {
+		"video-player": true,
+		"ai-recommendations": false,
+	},
+	"ai-integrations": {
+		"video-player": false,
+		"ai-recommendations": true,
+	},
+};
+
+export const ADMIN_PERMISSIONS: Record<RbacFeature, true> = {
+	"video-player": true,
+	"ai-recommendations": true,
+};

--- a/src/components/admin/admin-permission-toggles.tsx
+++ b/src/components/admin/admin-permission-toggles.tsx
@@ -20,15 +20,18 @@ const FEATURE_ROLES: Record<RbacFeature, PermissionRole> = {
 function ToggleSwitch({
 	enabled,
 	onChange,
+	ariaLabel,
 }: {
 	enabled: boolean;
 	onChange: (value: boolean) => void;
+	ariaLabel: string;
 }) {
 	return (
 		<button
 			type="button"
 			role="switch"
 			aria-checked={enabled}
+			aria-label={ariaLabel}
 			onClick={() => {
 				onChange(!enabled);
 			}}
@@ -79,6 +82,7 @@ function FeatureRow({
 					</span>
 					<ToggleSwitch
 						enabled={enabled}
+						ariaLabel={`${featureLabel} for ${ROLE_LABELS[role]}`}
 						onChange={(nextEnabled) => onToggle(role, nextEnabled)}
 					/>
 				</div>
@@ -123,9 +127,12 @@ export function AdminPermissionToggles() {
 						feature={feature as RbacFeature}
 						featureLabel={config.label}
 						permissionsByRole={permissionsByRole}
-						onToggle={(role, enabled) =>
-							setRolePermission({ role, feature, enabled })
-						}
+						onToggle={(role, enabled) => {
+							setRolePermission({ role, feature, enabled }).catch((err) => {
+								console.error("Failed to update role permission:", err);
+								alert(err instanceof Error ? err.message : String(err));
+							});
+						}}
 					/>
 				))}
 			</div>

--- a/src/components/homepage-media.tsx
+++ b/src/components/homepage-media.tsx
@@ -9,7 +9,7 @@ import {
 	getBasicTvDetails,
 	getMedia,
 } from "@/lib/queries";
-import type { MediaListResultsEntity } from "@/types";
+import type { BasicMovie, BasicTv, MediaListResultsEntity } from "@/types";
 
 interface MediaListProps extends MediaListResultsEntity {
 	is_on_watchlist_page?: boolean;
@@ -210,27 +210,44 @@ function ContinueWatchingContent({
 	const results = useQueries({ queries });
 
 	const isLoading = results.some((r) => r.isLoading);
-	const hasError = results.some((r) => r.isError);
 
 	if (isLoading) return <MediaSkeletonList cardType="vertical" />;
-	if (hasError) return null;
 
-	const mediaItems = results
-		.map((r, i) => {
+	const successfulItems = results
+		.map((result, index) => ({ result, item: items[index] }))
+		.filter(({ result }) => !result.isError && !!result.data);
+
+	if (successfulItems.length === 0) return null;
+
+	const mediaItems = successfulItems
+		.map(({ result: r, item }) => {
 			const data = r.data;
-			const item = items[i];
 			if (!data) return null;
 
-			const isMovie = item.type === "movie";
+			if (item.type === "movie") {
+				const movie = data as BasicMovie;
+				return {
+					id: movie.id,
+					title: movie.title,
+					vote_average: movie.vote_average ?? 0,
+					poster_path: movie.poster_path ?? "",
+					backdrop_path: movie.backdrop_path ?? "",
+					release_date: movie.release_date,
+					overview: movie.overview,
+					media_type: item.type,
+					isContinueWatching: true,
+				};
+			}
+
+			const tv = data as BasicTv;
 			return {
-				id: data.id,
-				title: isMovie ? (data as any).title : (data as any).name,
-				vote_average: (data as any).vote_average ?? 0,
-				poster_path: (data as any).poster_path ?? "",
-				backdrop_path: (data as any).backdrop_path ?? "",
-				first_air_date: isMovie ? undefined : (data as any).first_air_date,
-				release_date: isMovie ? (data as any).release_date : undefined,
-				overview: (data as any).overview,
+				id: tv.id,
+				title: tv.name,
+				vote_average: tv.vote_average ?? 0,
+				poster_path: tv.poster_path ?? "",
+				backdrop_path: tv.backdrop_path ?? "",
+				first_air_date: tv.first_air_date,
+				overview: tv.overview,
 				media_type: item.type,
 				isContinueWatching: true,
 			};

--- a/src/components/homepage-recommendations.tsx
+++ b/src/components/homepage-recommendations.tsx
@@ -39,6 +39,9 @@ interface NormalizedTmdbData {
 const getDismissKey = (rec: AIRecommendation) =>
 	`${rec.mediaType}:${rec.tmdbId ?? ""}:${rec.title}`;
 
+const getFeedbackKey = (mediaType: string | null | undefined, tmdbId: number) =>
+	`${mediaType ?? "unknown"}:${tmdbId}`;
+
 function normalizeTmdbData(
 	data: BasicMovie | BasicTv | null | undefined,
 	mediaType: "movie" | "tv",
@@ -176,7 +179,7 @@ const HomepageRecommendationCard = memo(
 		onFeedback,
 	}: {
 		recommendation: AIRecommendation;
-		likedIds: Set<number>;
+		likedIds: Set<string>;
 		onFeedback: (
 			rec: AIRecommendation,
 			resolvedId: number,
@@ -221,7 +224,7 @@ const HomepageRecommendationCard = memo(
 			return null;
 		}
 
-		const isLiked = likedIds.has(resolvedData.id);
+		const isLiked = likedIds.has(getFeedbackKey(mediaType, resolvedData.id));
 
 		return (
 			<div className="relative group/rec-card">
@@ -306,13 +309,25 @@ export function HomepageRecommendations() {
 	);
 
 	const [isGenerating, setIsGenerating] = useState(false);
+	const [hasRefreshFailed, setHasRefreshFailed] = useState(false);
 
 	useEffect(() => {
-		if (isSignedIn && recommendationsData?.needsRefresh && !isGenerating) {
+		if (
+			isSignedIn &&
+			recommendationsData?.needsRefresh &&
+			!isGenerating &&
+			!hasRefreshFailed
+		) {
 			setIsGenerating(true);
 			generateRecs()
+				.then((result) => {
+					if (result?.success === false) {
+						setHasRefreshFailed(true);
+					}
+				})
 				.catch((err) => {
 					console.error("Failed to generate homepage recommendations:", err);
+					setHasRefreshFailed(true);
 				})
 				.finally(() => {
 					setIsGenerating(false);
@@ -323,13 +338,14 @@ export function HomepageRecommendations() {
 		recommendationsData?.needsRefresh,
 		generateRecs,
 		isGenerating,
+		hasRefreshFailed,
 	]);
 
 	const likedIds = useMemo(() => {
-		const set = new Set<number>();
+		const set = new Set<string>();
 		for (const f of feedbackList ?? []) {
 			if (f.feedback === "like") {
-				set.add(f.tmdbId);
+				set.add(getFeedbackKey(f.mediaType, f.tmdbId));
 			}
 		}
 		return set;

--- a/src/components/media/watchlist-status-menu.tsx
+++ b/src/components/media/watchlist-status-menu.tsx
@@ -380,6 +380,7 @@ function AddToListDialog({
 									<button
 										key={list._id}
 										type="button"
+										aria-pressed={isInList}
 										className={cn(
 											"flex w-full items-center justify-between rounded-xl px-4 py-3 text-sm transition-all duration-200 border border-transparent",
 											isInList

--- a/src/components/share-button.tsx
+++ b/src/components/share-button.tsx
@@ -36,7 +36,11 @@ export const ShareButton = (props: {
 	}
 
 	return (
-		<Button variant="secondary" onClick={() => void handleShare()}>
+		<Button
+			variant="secondary"
+			aria-label="Share"
+			onClick={() => void handleShare()}
+		>
 			<span className="flex w-full items-center gap-1">
 				<ShareBold size={24} />
 				<span

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -106,23 +106,8 @@ export const MAX_PAGINATION_LIMIT = 500;
 export const HORIZONTAL_MEDIA_GRID_CLASS =
 	"grid w-full grid-cols-2 justify-items-center gap-5 px-1 py-10 sm:grid-cols-3 sm:px-0 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6";
 
-export const RBAC_ROLES = ["admin", "video-player", "ai-integrations"] as const;
-export type RbacRole = (typeof RBAC_ROLES)[number];
-export const PERMISSION_ROLES = ["video-player", "ai-integrations"] as const;
-export type PermissionRole = (typeof PERMISSION_ROLES)[number];
-
-export const RBAC_FEATURES = {
-	"video-player": {
-		label: "Video Playback",
-		description: "Built-in video player modal for streaming content",
-	},
-	"ai-recommendations": {
-		label: "AI Recommendations",
-		description:
-			"AI-powered personalized movie and TV recommendations via Gemini",
-	},
-} as const;
-export type RbacFeature = keyof typeof RBAC_FEATURES;
+export type { PermissionRole, RbacFeature, RbacRole } from "../shared/rbac";
+export { PERMISSION_ROLES, RBAC_FEATURES, RBAC_ROLES } from "../shared/rbac";
 
 export const DEFAULT_PLACEHOLDER_IMAGE =
 	"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTAiIGhlaWdodD0iNjAiIHZpZXdCb3g9IjAgMCA1MCA2MCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTM1LjYxNTQgMjBIMTQuMzg0NkMxNC4wMTc0IDIwIDEzLjY2NTIgMjAuMTUwOSAxMy40MDU2IDIwLjQxOTRDMTMuMTQ1OSAyMC42ODc5IDEzIDIxLjA1MjEgMTMgMjEuNDMxOFYzOS41NjgyQzEzIDM5Ljk0NzkgMTMuMTQ1OSA0MC4zMTIxIDEzLjQwNTYgNDAuNTgwNkMxMy42NjUyIDQwLjg0OTEgMTQuMDE3NCA0MSAxNC4zODQ2IDQxSDM1LjYxNTRDMzUuOTgyNiA0MSAzNi4zMzQ4IDQwLjg0OTEgMzYuNTk0NCA0MC41ODA2QzM2Ljg1NDEgNDAuMzEyMSAzNyAzOS45NDc5IDM3IDM5LjU2ODJWMjEuNDMxOEMzNyAyMS4wNTIxIDM2Ljg1NDEgMjAuNjg3OSAzNi41OTQ0IDIwLjQxOTRDMzYuMzM0OCAyMC4xNTA5IDM1Ljk4MjYgMjAgMzUuNjE1NCAyMFpNMzQuMjMwOCAzMi44ODY0TDI5LjgwNTMgMjcuODk0QzI5LjcyMTYgMjcuNzk4MyAyOS42MTk4IDI3LjcyMTIgMjkuNTA2MiAyNy42Njc2QzI5LjM5MjcgMjcuNjEzOSAyOS4yNjk4IDI3LjU4NDggMjkuMTQ1IDI3LjU4MkMyOS4wMjAyIDI3LjU3OTIgMjguODk2MSAyNy42MDI4IDI4Ljc4MDQgMjcuNjUxM0MyOC42NjQ3IDI3LjY5OTggMjguNTU5OCAyNy43NzIyIDI4LjQ3MjEgMjcuODY0MUwyMy41MzYxIDMyLjk2ODRMMjguNTMzNiAzOC4xMzY0SDI1LjkyMzFMMjEuNDk4OSAzMy41NjEyQzIxLjMyNTcgMzMuMzgyMyAyMS4wOTA5IDMzLjI4MTggMjAuODQ2MiAzMy4yODE4QzIwLjYwMTQgMzMuMjgxOCAyMC4zNjY2IDMzLjM4MjMgMjAuMTkzNSAzMy41NjEyTDE1Ljc2OTIgMzguMTM2NFYyMi44NjM2SDM0LjIzMDhWMzIuODg2NFpNMTcuNzA3NyAyNy4xNTkxQzE3LjcwNzcgMjYuNzA2IDE3LjgzNzYgMjYuMjYzMSAxOC4wODExIDI1Ljg4NjNDMTguMzI0NSAyNS41MDk2IDE4LjY3MDUgMjUuMjE2IDE5LjA3NTMgMjUuMDQyNkMxOS40ODAxIDI0Ljg2OTIgMTkuOTI1NSAyNC44MjM4IDIwLjM1NTMgMjQuOTEyMkMyMC43ODUgMjUuMDAwNiAyMS4xNzk4IDI1LjIxODggMjEuNDg5NiAyNS41MzkyQzIxLjc5OTQgMjUuODU5NiAyMi4wMTA0IDI2LjI2NzggMjIuMDk1OSAyNi43MTIyQzIyLjE4MTQgMjcuMTU2NSAyMi4xMzc1IDI3LjYxNzIgMjEuOTY5OCAyOC4wMzU4QzIxLjgwMjEgMjguNDU0NCAyMS41MTgyIDI4LjgxMjIgMjEuMTUzOSAyOS4wNjM5QzIwLjc4OTYgMjkuMzE1NiAyMC4zNjEyIDI5LjQ1IDE5LjkyMzEgMjkuNDVDMTkuMzM1NSAyOS40NSAxOC43NzIgMjkuMjA4NiAxOC4zNTY2IDI4Ljc3OUMxNy45NDExIDI4LjM0OTQgMTcuNzA3NyAyNy43NjY3IDE3LjcwNzcgMjcuMTU5MVoiIGZpbGw9IiNCNUI1QjUiLz4KPC9zdmc+Cg==";

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -32,7 +32,7 @@ export function usePermissions(): PermissionState & {
 
 	const clerkIsAdmin = user?.publicMetadata?.isAdmin === true;
 	const loading =
-		!isLoaded || (isSignedIn && !clerkIsAdmin && raw === undefined);
+		!isLoaded || (!!isSignedIn && !clerkIsAdmin && raw === undefined);
 
 	const features = clerkIsAdmin
 		? ({

--- a/src/hooks/useRecommendations.ts
+++ b/src/hooks/useRecommendations.ts
@@ -1,11 +1,10 @@
 import { useUser } from "@clerk/clerk-react";
 import { useAction, useMutation, useQuery } from "convex/react";
 import { useCallback, useState } from "react";
+import { usePermissions } from "@/hooks/usePermissions";
 import type { AIRecommendation } from "@/types";
 import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
-
-import { usePermissions } from "@/hooks/usePermissions";
 
 const QUERY_SKIP = "skip" as const;
 
@@ -66,6 +65,7 @@ export interface RecommendationHistoryEntry {
 	generationType?: string;
 	mediaTypePreference?: string;
 	genrePreference?: string;
+	listId?: string;
 	verified?: boolean;
 }
 
@@ -112,6 +112,7 @@ export function useRecommendations() {
 			generationType: entry.generationType ?? "watchlist",
 			mediaTypePreference: entry.mediaTypePreference,
 			genrePreference: entry.genrePreference,
+			listId: entry.listId,
 			verified: entry.verified ?? false,
 		}));
 

--- a/src/hooks/useWatchProgress.ts
+++ b/src/hooks/useWatchProgress.ts
@@ -1,12 +1,13 @@
 import { useUser } from "@clerk/clerk-react";
+import { useQuery as useReactQuery } from "@tanstack/react-query";
 
 import { useMutation, useQuery } from "convex/react";
 
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { api } from "../../convex/_generated/api";
-
 import type { Id } from "../../convex/_generated/dataModel";
+import { getTvDetails } from "../lib/queries";
 
 import { useLocalProgressStore } from "./useLocalProgressStore";
 
@@ -64,6 +65,20 @@ function makeEpisodeKey(
 	episode: number,
 ): string {
 	return `${tvId}:${season}:${episode}`;
+}
+
+function makeLastPlayedKey(
+	viewerId: string | null | undefined,
+	id: string | number,
+) {
+	return `last_played:${viewerId ?? "anon"}:${id}`;
+}
+
+function safeNextEpisode(episode: number, maxEpisodes?: number) {
+	if (typeof maxEpisodes === "number" && maxEpisodes > 0) {
+		return episode < maxEpisodes ? episode + 1 : episode;
+	}
+	return episode + 1;
 }
 
 const QUERY_SKIP = "skip" as const;
@@ -160,7 +175,7 @@ function createOptimisticEpisodeProgress(
 }
 
 export function usePlayerProgressListener() {
-	const { isSignedIn } = useUser();
+	const { isSignedIn, user } = useUser();
 	const updateProgress = useMutation(api.watchlist.updateProgress);
 	const markEpisodeWatchedMut = useMutation(api.watchlist.markEpisodeWatched);
 	const setLocalProgress = useWatchlistStore((state) => state.setProgressLocal);
@@ -227,7 +242,7 @@ export function usePlayerProgressListener() {
 			if (mediaType === "tv" && season !== undefined && episode !== undefined) {
 				try {
 					localStorage.setItem(
-						`last_played:${id}`,
+						makeLastPlayedKey(user?.id, id),
 						JSON.stringify({ season, episode }),
 					);
 				} catch {}
@@ -291,6 +306,7 @@ export function usePlayerProgressListener() {
 		isSignedIn,
 		setLocalProgress,
 		markLocalEpisode,
+		user?.id,
 	]);
 }
 
@@ -299,8 +315,24 @@ export function useWatchProgress(
 	mediaType: "movie" | "tv",
 ) {
 	const mediaState = useMediaState(String(id), mediaType);
-	const { isSignedIn } = useUser();
+	const { isSignedIn, user } = useUser();
 	const tmdbId = Number(id);
+
+	const { data: tvDetails } = useReactQuery({
+		queryKey: ["tv-details", tmdbId],
+		queryFn: () => getTvDetails({ id: tmdbId }),
+		enabled: mediaType === "tv" && Number.isFinite(tmdbId),
+		staleTime: 1000 * 60 * 60,
+	});
+
+	const seasonEpisodeCounts = useMemo(() => {
+		const counts = new Map<number, number>();
+		for (const season of tvDetails?.seasons ?? []) {
+			if (season.season_number === undefined) continue;
+			counts.set(season.season_number, season.episode_count ?? 0);
+		}
+		return counts;
+	}, [tvDetails?.seasons]);
 
 	const watchedEpisodes =
 		useQuery(
@@ -319,7 +351,7 @@ export function useWatchProgress(
 			// First, check if there's a last-played episode in localStorage
 			const lastPlayedStr =
 				typeof window !== "undefined"
-					? localStorage.getItem(`last_played:${id}`)
+					? localStorage.getItem(makeLastPlayedKey(user?.id, id))
 					: null;
 			if (lastPlayedStr) {
 				try {
@@ -334,7 +366,13 @@ export function useWatchProgress(
 							: !!localEpisodes[`${tmdbId}:${season}:${episode}`];
 
 						if (isThisWatched) {
-							context = { season, episode: episode + 1 };
+							context = {
+								season,
+								episode: safeNextEpisode(
+									episode,
+									seasonEpisodeCounts.get(season),
+								),
+							};
 						} else {
 							context = { season, episode };
 						}
@@ -363,7 +401,10 @@ export function useWatchProgress(
 					const lastWatched = watchedList[watchedList.length - 1];
 					context = {
 						season: lastWatched.season,
-						episode: lastWatched.episode + 1,
+						episode: safeNextEpisode(
+							lastWatched.episode,
+							seasonEpisodeCounts.get(lastWatched.season),
+						),
 					};
 				} else {
 					context = {
@@ -391,6 +432,8 @@ export function useWatchProgress(
 		localEpisodes,
 		tmdbId,
 		id,
+		user?.id,
+		seasonEpisodeCounts,
 	]);
 
 	return { progress };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -10,13 +10,24 @@ const VALID_PROGRESS_STATUSES: ReadonlySet<string> = new Set([
 	"dropped",
 ]);
 
+const LEGACY_STATUS_MAP: ReadonlyMap<string, ProgressStatus> = new Map([
+	["planned", "watch-later"],
+	["plan-to-watch", "watch-later"],
+	["watch_later", "watch-later"],
+	["in-progress", "watching"],
+	["watching-now", "watching"],
+	["completed", "done"],
+	["watched", "done"],
+	["finished", "done"],
+	["abandoned", "dropped"],
+]);
+
 export function normalizeProgressStatus(
 	status?: string | null,
 ): ProgressStatus | null {
 	if (!status) return null;
-	return VALID_PROGRESS_STATUSES.has(status)
-		? (status as ProgressStatus)
-		: null;
+	if (VALID_PROGRESS_STATUSES.has(status)) return status as ProgressStatus;
+	return LEGACY_STATUS_MAP.get(status) ?? null;
 }
 
 interface ApiResponse<T> {

--- a/src/routes/keyword.$id.tsx
+++ b/src/routes/keyword.$id.tsx
@@ -39,7 +39,7 @@ export const Route = createFileRoute("/keyword/$id")({
 			},
 			{
 				name: "description",
-				content: `Explore movies tagged with ${loaderData?.keyword.name} on Pebbly.`,
+				content: `Explore movies tagged with ${loaderData?.keyword?.name ?? "this keyword"} on Pebbly.`,
 			},
 		],
 	}),

--- a/src/routes/recommendations.tsx
+++ b/src/routes/recommendations.tsx
@@ -117,16 +117,26 @@ function normalizeTitleKey(title?: string | null): string {
 	return (title ?? "").toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
+function getTrackedKey(mediaType: string, tmdbId: number) {
+	return `${mediaType}:${tmdbId}`;
+}
+
 function isTrackedRecommendation(
 	recommendation: AIRecommendation,
-	trackedIds: Set<number>,
+	trackedIds: Set<string>,
 	trackedTitles: Set<string>,
 ) {
 	const candidateIds = [
 		recommendation.tmdbId,
 		recommendation.verifiedTmdbId,
 	].filter((id): id is number => typeof id === "number");
-	if (candidateIds.some((id) => trackedIds.has(id))) return true;
+	if (
+		candidateIds.some((id) =>
+			trackedIds.has(getTrackedKey(recommendation.mediaType, id)),
+		)
+	) {
+		return true;
+	}
 
 	const candidateTitles = [
 		recommendation.title,
@@ -310,8 +320,17 @@ function RecommendationsContent({ isSignedIn }: { isSignedIn: boolean }) {
 		api.watchlist.getTrackedTmdbIds,
 		isSignedIn ? {} : "skip",
 	);
-	const trackedIdSet = useMemo<Set<number>>(
-		() => new Set((trackedTmdbIds ?? []) as number[]),
+	const trackedIdSet = useMemo<Set<string>>(
+		() =>
+			new Set(
+				(trackedTmdbIds ?? []).map((item) =>
+					getTrackedKey(item.mediaType, item.tmdbId),
+				),
+			),
+		[trackedTmdbIds],
+	);
+	const trackedTmdbIdSet = useMemo<Set<number>>(
+		() => new Set((trackedTmdbIds ?? []).map((item) => item.tmdbId)),
 		[trackedTmdbIds],
 	);
 	const trackedTitleSet = useMemo(
@@ -406,8 +425,8 @@ function RecommendationsContent({ isSignedIn }: { isSignedIn: boolean }) {
 			options.yearTo = Math.max(...matchedEras.map((e) => e.to));
 		}
 
-		if (trackedIdSet.size > 0) {
-			options.excludeTmdbIds = Array.from(trackedIdSet);
+		if (trackedTmdbIdSet.size > 0) {
+			options.excludeTmdbIds = Array.from(trackedTmdbIdSet);
 		}
 
 		options.count = count;
@@ -422,8 +441,11 @@ function RecommendationsContent({ isSignedIn }: { isSignedIn: boolean }) {
 		if (entry.mediaTypePreference)
 			options.mediaTypePreference = entry.mediaTypePreference as "movie" | "tv";
 		if (entry.genrePreference) options.genrePreference = entry.genrePreference;
-		if (trackedIdSet.size > 0) {
-			options.excludeTmdbIds = Array.from(trackedIdSet);
+		if (entry.generationType === "list" && entry.listId) {
+			options.listId = entry.listId;
+		}
+		if (trackedTmdbIdSet.size > 0) {
+			options.excludeTmdbIds = Array.from(trackedTmdbIdSet);
 		}
 		options.count = count;
 		generate(options);
@@ -437,13 +459,16 @@ function RecommendationsContent({ isSignedIn }: { isSignedIn: boolean }) {
 		if (entry.mediaTypePreference)
 			options.mediaTypePreference = entry.mediaTypePreference as "movie" | "tv";
 		if (entry.genrePreference) options.genrePreference = entry.genrePreference;
+		if (entry.generationType === "list" && entry.listId) {
+			options.listId = entry.listId;
+		}
 
 		options.excludeTmdbIds = [
 			...new Set([
 				...entry.recommendations
 					.flatMap((r) => [r.tmdbId, r.verifiedTmdbId])
 					.filter((id): id is number => typeof id === "number"),
-				...Array.from(trackedIdSet),
+				...Array.from(trackedTmdbIdSet),
 			]),
 		];
 

--- a/src/routes/watchlist.tsx
+++ b/src/routes/watchlist.tsx
@@ -603,9 +603,16 @@ function MyListsTabContent() {
 							color: selectedList.color,
 						})
 					}
-					onDelete={() => {
-						deleteCustomList({ listId: selectedList._id as Id<"lists"> });
-						setSelectedListId(null);
+					onDelete={async () => {
+						try {
+							await deleteCustomList({
+								listId: selectedList._id as Id<"lists">,
+							});
+							setSelectedListId(null);
+						} catch (error) {
+							console.error("Failed to delete custom list:", error);
+							alert(error instanceof Error ? error.message : String(error));
+						}
 					}}
 				/>
 				{editingList && (
@@ -688,9 +695,15 @@ function MyListsTabContent() {
 									color: list.color,
 								})
 							}
-							onDelete={() =>
-								deleteCustomList({ listId: list._id as Id<"lists"> })
-							}
+							onDelete={async () => {
+								try {
+									await deleteCustomList({ listId: list._id as Id<"lists"> });
+									if (selectedListId === list._id) setSelectedListId(null);
+								} catch (error) {
+									console.error("Failed to delete custom list:", error);
+									alert(error instanceof Error ? error.message : String(error));
+								}
+							}}
 						/>
 					))}
 				</div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -199,6 +199,7 @@
 	}
 	body {
 		@apply bg-background text-foreground;
+
 		padding-top: env(safe-area-inset-top);
 		padding-bottom: env(safe-area-inset-bottom);
 		padding-left: env(safe-area-inset-left);


### PR DESCRIPTION
### Motivation
- Centralize RBAC roles/features so frontend and Convex logic cannot drift and enforce admin-only reads for role permissions.
- Prevent AI recommendation endpoints and cached data from being read or written when the `ai-recommendations` feature is disabled and ensure feedback/dismissals respect media type.
- Preserve admin/role behavior for legacy data and avoid misclassification by backfilling `users.roles` from the legacy `role` field.
- Improve UX/accessibility and data correctness for playback state, continue-watching rows, share controls, custom-list deletion, and admin toggles.

### Description
- Added a Convex-safe shared RBAC module (`shared/rbac.ts`) and re-exported types/values from `src/constants.ts`, and updated `convex/admin.ts` to consume the shared definitions and keep defaults centralized.
- Hardened admin endpoints by calling `requireAdmin(ctx)` in `getRolePermissions`, added `migrateLegacyUserRoles` admin mutation to backfill `users.roles`, and preserved the legacy `role` schema field with a TODO in `convex/schema.ts` and `convex/users.ts` to migrate existing docs.
- Gate AI recommendation handlers with `hasFeature(ctx, "ai-recommendations")` and make recommendation feedback/dismissal/tracked IDs media-type-aware by using composite keys (e.g., `${mediaType}:${tmdbId}`) and preserve `listId` when replaying list-based generations across `convex/recommendations.ts`, frontend hooks, and route handlers.
- Return media-type-aware tracked IDs from `convex/watchlist.getTrackedTmdbIds`, make homepage recommendation liked/dismissal sets use composite keys, prevent tight generate-recs retry loops by tracking refresh failures, and filter out failed queries in the continue-watching row instead of dropping the whole row.
- Namespace `last_played` localStorage keys by viewer id and add `safeNextEpisode` logic using season metadata to avoid out-of-range next-episode values; change playback-derived progress status to take precedence over stale statuses in `convex/watchlist.ts` and `src/hooks/useWatchProgress.ts`.
- Accessibility and UX fixes: add `aria-label` to admin toggle switches and share button, add `.catch` error handling to role-permission mutation calls, set `aria-pressed` on list buttons, make custom-list deletion await the mutation and handle/report errors, and add a backward-compatible legacy progress status mapping in `src/lib/utils.ts`.

### Testing
- Ran `npx biome check` (targeted files) and the project linter fixed/organized imports where applicable and reported no new issues in the modified files; this check completed successfully for the changed files. 
- Ran `npx tsc --noEmit` which succeeded (typecheck passed for the edits). 
- Ran `npm run check` which still reports pre-existing Biome findings in unrelated files (e.g., `media-poster-trailer-container.tsx`, `ui/icons.tsx`, `search-bar.tsx`, `video-player-modal.tsx`, `routes/index.tsx`), so those unrelated lint findings remain unresolved. 
- Ran `npm run build`: client and SSR bundles were produced successfully, but prerender failed when fetching `/` with an `Internal Server Error` during prerendering (likely unrelated runtime/environment issue surfaced during prerender).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d1c35ecbc832e9f28b3e81cf2050f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Per-user watch progress tracking for multi-account households
  * Admin role migration tool for legacy user accounts
  * Feature flag controls for AI recommendations

* **Improvements**
  * Enhanced media type distinction in recommendation filtering to properly handle duplicates
  * Improved error handling and user feedback in admin and list management flows
  * Better TV show next-episode selection logic using accurate episode counts
  * Accessibility improvements with added aria-labels

* **Bug Fixes**
  * Fixed progress status calculation to use inferred status when available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->